### PR TITLE
[BE] Implement admin product catalog read endpoints

### DIFF
--- a/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductDetailsResponseDto.java
+++ b/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductDetailsResponseDto.java
@@ -1,0 +1,21 @@
+package com.challengeteam.shop.dto.admin.product;
+
+import com.challengeteam.shop.dto.image.ImageMetadataResponseDto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AdminProductDetailsResponseDto(
+    Long id,
+    String name,
+    String description,
+    BigDecimal price,
+    String brand,
+    Integer releaseYear,
+    String cpu,
+    Integer coresNumber,
+    String screenSize,
+    String frontCamera,
+    String mainCamera,
+    String batteryCapacity,
+    List<ImageMetadataResponseDto> images) {}

--- a/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductFilterDto.java
+++ b/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductFilterDto.java
@@ -1,0 +1,25 @@
+package com.challengeteam.shop.dto.admin.product;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+
+public record AdminProductFilterDto(
+    @Size(max = 100, message = "Search length must be less than or equal to 100 characters")
+        String search,
+    String brand,
+    @DecimalMin(value = "0.0", message = "Minimum price cannot be negative") BigDecimal minPrice,
+    @DecimalMin(value = "0.0", message = "Maximum price cannot be negative") BigDecimal maxPrice,
+    @Pattern(
+            regexp =
+                "name_asc|name_desc|price_asc|price_desc|releaseYear_asc|releaseYear_desc|brand_asc|brand_desc",
+            message =
+                "Sort must be one of: name_asc, name_desc, price_asc, price_desc, releaseYear_asc, releaseYear_desc, brand_asc, brand_desc")
+        String sort) {
+  public AdminProductFilterDto {
+    sort = (sort == null || sort.isBlank()) ? "name_asc" : sort;
+  }
+}

--- a/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductListItemResponseDto.java
+++ b/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductListItemResponseDto.java
@@ -1,0 +1,13 @@
+package com.challengeteam.shop.dto.admin.product;
+
+import com.challengeteam.shop.dto.image.ImageMetadataResponseDto;
+
+import java.math.BigDecimal;
+
+public record AdminProductListItemResponseDto(
+    Long id,
+    String name,
+    String brand,
+    BigDecimal price,
+    Integer releaseYear,
+    ImageMetadataResponseDto previewImage) {}

--- a/src/main/java/com/challengeteam/shop/mapper/AdminProductMapper.java
+++ b/src/main/java/com/challengeteam/shop/mapper/AdminProductMapper.java
@@ -1,0 +1,53 @@
+package com.challengeteam.shop.mapper;
+
+import com.challengeteam.shop.dto.admin.product.AdminProductDetailsResponseDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductListItemResponseDto;
+import com.challengeteam.shop.dto.image.ImageMetadataResponseDto;
+import com.challengeteam.shop.entity.image.Image;
+import com.challengeteam.shop.entity.phone.Phone;
+import com.challengeteam.shop.entity.phone.PhoneCharacteristics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AdminProductMapper {
+  private final ImageMapper imageMapper;
+
+  public AdminProductListItemResponseDto toListItem(Phone phone) {
+    return new AdminProductListItemResponseDto(
+        phone.getId(),
+        phone.getName(),
+        phone.getBrand(),
+        phone.getPrice(),
+        phone.getReleaseYear(),
+        toPreviewImage(phone.getImages()));
+  }
+
+  public AdminProductDetailsResponseDto toDetails(Phone phone) {
+    PhoneCharacteristics characteristics = phone.getPhoneCharacteristics();
+
+    return new AdminProductDetailsResponseDto(
+        phone.getId(),
+        phone.getName(),
+        phone.getDescription(),
+        phone.getPrice(),
+        phone.getBrand(),
+        phone.getReleaseYear(),
+        characteristics != null ? characteristics.getCpu() : null,
+        characteristics != null ? characteristics.getCoresNumber() : null,
+        characteristics != null ? characteristics.getScreenSize() : null,
+        characteristics != null ? characteristics.getFrontCamera() : null,
+        characteristics != null ? characteristics.getMainCamera() : null,
+        characteristics != null ? characteristics.getBatteryCapacity() : null,
+        phone.getImages() == null ? List.of() : imageMapper.toListOfMetadata(phone.getImages()));
+  }
+
+  private ImageMetadataResponseDto toPreviewImage(List<Image> images) {
+    if (images == null || images.isEmpty()) return null;
+
+    return imageMapper.toMetadata(images.getFirst());
+  }
+}

--- a/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
+++ b/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
@@ -1,0 +1,78 @@
+package com.challengeteam.shop.persistence.specification;
+
+import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
+import com.challengeteam.shop.entity.phone.Phone;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public final class AdminProductSpecification {
+
+  private AdminProductSpecification() {}
+
+  public static Specification<Phone> build(AdminProductFilterDto filterDto) {
+    Specification<Phone> spec = fetchImages();
+
+    spec = addIfHasText(spec, filterDto.search(), AdminProductSpecification::matchesSearch);
+    spec = addIfHasText(spec, filterDto.brand(), AdminProductSpecification::hasBrand);
+    spec =
+        addIfPresent(
+            spec, filterDto.minPrice(), AdminProductSpecification::priceGreaterThanOrEqual);
+    spec =
+        addIfPresent(spec, filterDto.maxPrice(), AdminProductSpecification::priceLessThanOrEqual);
+
+    return spec;
+  }
+
+  public static Specification<Phone> fetchImages() {
+    return (root, query, cb) -> {
+      Objects.requireNonNull(query);
+
+      if (query.getResultType() != Long.class && query.getResultType() != long.class) {
+        root.fetch("images", JoinType.LEFT);
+        query.distinct(true);
+      }
+
+      return cb.conjunction();
+    };
+  }
+
+  public static Specification<Phone> matchesSearch(String search) {
+    return (root, query, cb) -> {
+      String pattern = "%" + search.toLowerCase() + "%";
+
+      return cb.or(
+          cb.like(cb.lower(root.get("name")), pattern),
+          cb.like(cb.lower(root.get("brand")), pattern),
+          cb.like(cb.lower(root.get("description")), pattern));
+    };
+  }
+
+  public static Specification<Phone> hasBrand(String brand) {
+    return (root, query, cb) -> cb.equal(cb.lower(root.get("brand")), brand.toLowerCase());
+  }
+
+  public static Specification<Phone> priceGreaterThanOrEqual(BigDecimal minPrice) {
+    return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("price"), minPrice);
+  }
+
+  public static Specification<Phone> priceLessThanOrEqual(BigDecimal maxPrice) {
+    return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("price"), maxPrice);
+  }
+
+  private static <T> Specification<Phone> addIfPresent(
+      Specification<Phone> spec,
+      T value,
+      java.util.function.Function<T, Specification<Phone>> specificationFactory) {
+    return value == null ? spec : spec.and(specificationFactory.apply(value));
+  }
+
+  private static Specification<Phone> addIfHasText(
+      Specification<Phone> spec,
+      String value,
+      java.util.function.Function<String, Specification<Phone>> specificationFactory) {
+    return value == null || value.isBlank() ? spec : spec.and(specificationFactory.apply(value));
+  }
+}

--- a/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
+++ b/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import java.util.function.Function;
 
 public final class AdminProductSpecification {
 
@@ -26,7 +27,7 @@ public final class AdminProductSpecification {
     return spec;
   }
 
-  public static Specification<Phone> fetchImages() {
+  private static Specification<Phone> fetchImages() {
     return (root, query, cb) -> {
       Objects.requireNonNull(query);
 
@@ -39,7 +40,7 @@ public final class AdminProductSpecification {
     };
   }
 
-  public static Specification<Phone> matchesSearch(String search) {
+  private static Specification<Phone> matchesSearch(String search) {
     return (root, query, cb) -> {
       String pattern = "%" + search.toLowerCase() + "%";
 
@@ -50,29 +51,27 @@ public final class AdminProductSpecification {
     };
   }
 
-  public static Specification<Phone> hasBrand(String brand) {
+  private static Specification<Phone> hasBrand(String brand) {
     return (root, query, cb) -> cb.equal(cb.lower(root.get("brand")), brand.toLowerCase());
   }
 
-  public static Specification<Phone> priceGreaterThanOrEqual(BigDecimal minPrice) {
+  private static Specification<Phone> priceGreaterThanOrEqual(BigDecimal minPrice) {
     return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("price"), minPrice);
   }
 
-  public static Specification<Phone> priceLessThanOrEqual(BigDecimal maxPrice) {
+  private static Specification<Phone> priceLessThanOrEqual(BigDecimal maxPrice) {
     return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("price"), maxPrice);
   }
 
   private static <T> Specification<Phone> addIfPresent(
-      Specification<Phone> spec,
-      T value,
-      java.util.function.Function<T, Specification<Phone>> specificationFactory) {
+      Specification<Phone> spec, T value, Function<T, Specification<Phone>> specificationFactory) {
     return value == null ? spec : spec.and(specificationFactory.apply(value));
   }
 
   private static Specification<Phone> addIfHasText(
       Specification<Phone> spec,
       String value,
-      java.util.function.Function<String, Specification<Phone>> specificationFactory) {
+      Function<String, Specification<Phone>> specificationFactory) {
     return value == null || value.isBlank() ? spec : spec.and(specificationFactory.apply(value));
   }
 }

--- a/src/main/java/com/challengeteam/shop/service/admin/AdminProductQueryService.java
+++ b/src/main/java/com/challengeteam/shop/service/admin/AdminProductQueryService.java
@@ -1,0 +1,13 @@
+package com.challengeteam.shop.service.admin;
+
+import com.challengeteam.shop.dto.admin.product.AdminProductDetailsResponseDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductListItemResponseDto;
+import org.springframework.data.domain.Page;
+
+public interface AdminProductQueryService {
+  Page<AdminProductListItemResponseDto> getProducts(
+      int page, int size, AdminProductFilterDto filterDto);
+
+  AdminProductDetailsResponseDto getProductById(Long id);
+}

--- a/src/main/java/com/challengeteam/shop/service/admin/impl/AdminProductQueryServiceImpl.java
+++ b/src/main/java/com/challengeteam/shop/service/admin/impl/AdminProductQueryServiceImpl.java
@@ -1,0 +1,60 @@
+package com.challengeteam.shop.service.admin.impl;
+
+import com.challengeteam.shop.dto.admin.product.AdminProductDetailsResponseDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductListItemResponseDto;
+import com.challengeteam.shop.entity.phone.Phone;
+import com.challengeteam.shop.exceptionHandling.exception.ResourceNotFoundException;
+import com.challengeteam.shop.mapper.AdminProductMapper;
+import com.challengeteam.shop.persistence.repository.PhoneRepository;
+import com.challengeteam.shop.persistence.specification.AdminProductSpecification;
+import com.challengeteam.shop.service.admin.AdminProductQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminProductQueryServiceImpl implements AdminProductQueryService {
+
+  private final PhoneRepository phoneRepository;
+  private final AdminProductMapper adminProductMapper;
+
+  @Override
+  public Page<AdminProductListItemResponseDto> getProducts(
+      int page, int size, AdminProductFilterDto filterDto) {
+    Pageable pageable = PageRequest.of(page, size, buildSort(filterDto.sort()));
+    Specification<Phone> specification = AdminProductSpecification.build(filterDto);
+
+    return phoneRepository.findAll(specification, pageable).map(adminProductMapper::toListItem);
+  }
+
+  @Override
+  public AdminProductDetailsResponseDto getProductById(Long id) {
+    Phone phone =
+        phoneRepository
+            .findByIdWithImages(id)
+            .orElseThrow(() -> new ResourceNotFoundException("Not found product with id: " + id));
+
+    return adminProductMapper.toDetails(phone);
+  }
+
+  private Sort buildSort(String sort) {
+    return switch (sort) {
+      case "name_desc" -> Sort.by("name").descending();
+      case "price_asc" -> Sort.by("price").ascending();
+      case "price_desc" -> Sort.by("price").descending();
+      case "releaseYear_asc" -> Sort.by("releaseYear").ascending();
+      case "releaseYear_desc" -> Sort.by("releaseYear").descending();
+      case "brand_asc" -> Sort.by("brand").ascending();
+      case "brand_desc" -> Sort.by("brand").descending();
+      default -> Sort.by("name").ascending();
+    };
+  }
+}

--- a/src/main/java/com/challengeteam/shop/web/controller/PhoneController.java
+++ b/src/main/java/com/challengeteam/shop/web/controller/PhoneController.java
@@ -29,8 +29,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.challengeteam.shop.web.controller.admin.AdminProductController.getPageResponseDtoResponseEntity;
-
 @RestController
 @RequestMapping("/api/v1/phones")
 @RequiredArgsConstructor
@@ -43,17 +41,22 @@ public class PhoneController {
 
     @Operation(
             summary = "Get paginated list of phones",
-            description = "Returns a paginated list of phones. " +
-                          "Use 'page' and 'size' query parameters to control pagination."
+            description = "Returns a paginated list of phones. Use 'page' and 'size' query parameters to control pagination."
     )
     @GetMapping
     public ResponseEntity<PageResponseDto<PhoneResponseDto>> getAllPhones(
             @Valid PageRequestDto pageRequestDto,
             @Valid PhoneFilterDto filterDto
     ) {
+        int page = pageRequestDto.page() - 1;
+        int size = pageRequestDto.size();
 
-        return getPageResponseDtoResponseEntity(pageRequestDto, filterDto, phoneService, phoneMapper);
+        Page<Phone> phones = phoneService.getPhones(page, size, filterDto);
+        Page<PhoneResponseDto> response = phones.map(phoneMapper::toResponse);
+
+        return ResponseEntity.ok(PageResponseDto.of(response));
     }
+
 
     @Operation(
             summary = "Get phone by id",

--- a/src/main/java/com/challengeteam/shop/web/controller/admin/AdminProductController.java
+++ b/src/main/java/com/challengeteam/shop/web/controller/admin/AdminProductController.java
@@ -1,13 +1,16 @@
 package com.challengeteam.shop.web.controller.admin;
 
+import com.challengeteam.shop.dto.admin.product.AdminProductDetailsResponseDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
+import com.challengeteam.shop.dto.admin.product.AdminProductListItemResponseDto;
 import com.challengeteam.shop.dto.pagination.PageRequestDto;
 import com.challengeteam.shop.dto.pagination.PageResponseDto;
 import com.challengeteam.shop.dto.pagination.PhoneFilterDto;
 import com.challengeteam.shop.dto.phone.PhoneResponseDto;
 import com.challengeteam.shop.entity.phone.Phone;
-import com.challengeteam.shop.exceptionHandling.exception.ResourceNotFoundException;
 import com.challengeteam.shop.mapper.PhoneMapper;
 import com.challengeteam.shop.service.PhoneService;
+import com.challengeteam.shop.service.admin.AdminProductQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
@@ -27,16 +30,22 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearer-jwt")
 @Validated
 public class AdminProductController {
-  private final PhoneService phoneService;
-  private final PhoneMapper phoneMapper;
+  private final AdminProductQueryService adminProductQueryService;
 
   @Operation(
       summary = "Get admin product list",
-      description = "Returns a paginated list of products for admin section.")
+      description =
+          "Returns a paginated list of products for admin section with admin-specific filtering and sorting.")
   @GetMapping
-  public ResponseEntity<PageResponseDto<PhoneResponseDto>> getAllProducts(
-      @Valid PageRequestDto pageRequestDto, @Valid PhoneFilterDto filterDto) {
-    return getPageResponseDtoResponseEntity(pageRequestDto, filterDto, phoneService, phoneMapper);
+  public ResponseEntity<PageResponseDto<AdminProductListItemResponseDto>> getAllProducts(
+      @Valid PageRequestDto pageRequestDto, @Valid AdminProductFilterDto filterDto) {
+    int page = pageRequestDto.page() - 1;
+    int size = pageRequestDto.size();
+
+    Page<AdminProductListItemResponseDto> products =
+        adminProductQueryService.getProducts(page, size, filterDto);
+
+    return ResponseEntity.ok(PageResponseDto.of(products));
   }
 
   @NonNull
@@ -55,15 +64,11 @@ public class AdminProductController {
   }
 
   @Operation(
-      summary = "Get admin product by id",
-      description = "Returns product details for admin section.")
+      summary = "Get admin product details by id",
+      description =
+          "Returns full product details required for admin overview and future edit form.")
   @GetMapping("/{id:\\d+}")
-  public ResponseEntity<PhoneResponseDto> getProductById(@PathVariable Long id) {
-    Phone phone =
-        phoneService
-            .getById(id)
-            .orElseThrow(() -> new ResourceNotFoundException("Not found product with id: " + id));
-
-    return ResponseEntity.ok(phoneMapper.toResponse(phone));
+  public ResponseEntity<AdminProductDetailsResponseDto> getProductById(@PathVariable Long id) {
+    return ResponseEntity.ok(adminProductQueryService.getProductById(id));
   }
 }

--- a/src/main/java/com/challengeteam/shop/web/controller/admin/AdminProductController.java
+++ b/src/main/java/com/challengeteam/shop/web/controller/admin/AdminProductController.java
@@ -5,17 +5,11 @@ import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
 import com.challengeteam.shop.dto.admin.product.AdminProductListItemResponseDto;
 import com.challengeteam.shop.dto.pagination.PageRequestDto;
 import com.challengeteam.shop.dto.pagination.PageResponseDto;
-import com.challengeteam.shop.dto.pagination.PhoneFilterDto;
-import com.challengeteam.shop.dto.phone.PhoneResponseDto;
-import com.challengeteam.shop.entity.phone.Phone;
-import com.challengeteam.shop.mapper.PhoneMapper;
-import com.challengeteam.shop.service.PhoneService;
 import com.challengeteam.shop.service.admin.AdminProductQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -30,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearer-jwt")
 @Validated
 public class AdminProductController {
+
   private final AdminProductQueryService adminProductQueryService;
 
   @Operation(
@@ -46,21 +41,6 @@ public class AdminProductController {
         adminProductQueryService.getProducts(page, size, filterDto);
 
     return ResponseEntity.ok(PageResponseDto.of(products));
-  }
-
-  @NonNull
-  public static ResponseEntity<PageResponseDto<PhoneResponseDto>> getPageResponseDtoResponseEntity(
-      @Valid PageRequestDto pageRequestDto,
-      @Valid PhoneFilterDto filterDto,
-      PhoneService phoneService,
-      PhoneMapper phoneMapper) {
-    int page = pageRequestDto.page() - 1;
-    int size = pageRequestDto.size();
-
-    Page<Phone> phones = phoneService.getPhones(page, size, filterDto);
-    Page<PhoneResponseDto> response = phones.map(phoneMapper::toResponse);
-
-    return ResponseEntity.ok(PageResponseDto.of(response));
   }
 
   @Operation(

--- a/src/test/java/com/challengeteam/shop/web/controller/AdminControllerTest.java
+++ b/src/test/java/com/challengeteam/shop/web/controller/AdminControllerTest.java
@@ -1,6 +1,7 @@
 package com.challengeteam.shop.web.controller;
 
 import com.challengeteam.shop.dto.phone.PhoneCreateRequestDto;
+import com.challengeteam.shop.entity.phone.Phone;
 import com.challengeteam.shop.entity.user.Role;
 import com.challengeteam.shop.entity.user.User;
 import com.challengeteam.shop.persistence.repository.PhoneRepository;
@@ -46,12 +47,19 @@ class AdminControllerTest {
   private static final String ADMIN_PASSWORD = "AdminPassword123!";
 
   @Autowired private MockMvc mockMvc;
+
   @Autowired private TestAuthHelper testAuthHelper;
+
   @Autowired private JwtService jwtService;
+
   @Autowired private UserRepository userRepository;
+
   @Autowired private RoleRepository roleRepository;
+
   @Autowired private PhoneRepository phoneRepository;
+
   @Autowired private PhoneService phoneService;
+
   @Autowired private PasswordEncoder passwordEncoder;
 
   private String userToken;
@@ -70,7 +78,7 @@ class AdminControllerTest {
     userToken = testAuthHelper.authorizeLikeTestUser();
     adminToken = createAdminAccessToken();
 
-    phoneService.create(buildPhoneCreateRequestDto(), new ArrayList<>());
+    phoneService.create(buildAdminTestPhoneCreateRequestDto(), new ArrayList<>());
   }
 
   @Nested
@@ -111,14 +119,125 @@ class AdminControllerTest {
   class GetAdminProductsTest {
 
     @Test
-    void whenAuthenticatedUserIsAdmin_thenStatus200() throws Exception {
+    void whenAuthenticatedUserHasNoAdminRole_thenStatus403() throws Exception {
+      mockMvc
+          .perform(get(ADMIN_PRODUCTS_URL).header(HttpHeaders.AUTHORIZATION, auth(userToken)))
+          .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void whenAuthenticatedUserIsAdmin_thenStatus200AndReturnAdminProductList() throws Exception {
       mockMvc
           .perform(get(ADMIN_PRODUCTS_URL).header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("$.content").isArray())
           .andExpect(jsonPath("$.content", hasSize(1)))
+          .andExpect(jsonPath("$.content[0].id").isNumber())
+          .andExpect(jsonPath("$.content[0].name").value("Admin Test Phone"))
+          .andExpect(jsonPath("$.content[0].brand").value("AdminBrand"))
+          .andExpect(jsonPath("$.content[0].price").value(799.99))
+          .andExpect(jsonPath("$.content[0].releaseYear").value(2024))
+          .andExpect(jsonPath("$.content[0].previewImage").doesNotExist());
+    }
+
+    @Test
+    void whenSearchMatchesProduct_thenReturnFilteredList() throws Exception {
+      phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL)
+                  .param("search", "admin")
+                  .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.content", hasSize(1)))
           .andExpect(jsonPath("$.content[0].name").value("Admin Test Phone"));
+    }
+
+    @Test
+    void whenBrandFilterMatchesProduct_thenReturnFilteredList() throws Exception {
+      phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL)
+                  .param("brand", "AdminBrand")
+                  .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.content", hasSize(1)))
+          .andExpect(jsonPath("$.content[0].brand").value("AdminBrand"));
+    }
+
+    @Test
+    void whenSortByPriceDesc_thenReturnProductsInSortedOrder() throws Exception {
+      phoneService.create(buildMoreExpensivePhoneCreateRequestDto(), new ArrayList<>());
+
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL)
+                  .param("sort", "price_desc")
+                  .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.content", hasSize(2)))
+          .andExpect(jsonPath("$.content[0].name").value("Premium Test Phone"))
+          .andExpect(jsonPath("$.content[0].price").value(1499.99))
+          .andExpect(jsonPath("$.content[1].name").value("Admin Test Phone"))
+          .andExpect(jsonPath("$.content[1].price").value(799.99));
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/v1/admin/products/{id}")
+  class GetAdminProductDetailsTest {
+
+    @Test
+    void whenProductExists_thenReturnFullAdminDetails() throws Exception {
+      Phone phone = phoneRepository.findAll().getFirst();
+
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL + "/{id}", phone.getId())
+                  .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.id").value(phone.getId()))
+          .andExpect(jsonPath("$.name").value("Admin Test Phone"))
+          .andExpect(jsonPath("$.description").value("Phone prepared for admin controller tests"))
+          .andExpect(jsonPath("$.brand").value("AdminBrand"))
+          .andExpect(jsonPath("$.price").value(799.99))
+          .andExpect(jsonPath("$.releaseYear").value(2024))
+          .andExpect(jsonPath("$.cpu").value("Admin Chip"))
+          .andExpect(jsonPath("$.coresNumber").value(8))
+          .andExpect(jsonPath("$.screenSize").value("6.5\""))
+          .andExpect(jsonPath("$.frontCamera").value("12 MP"))
+          .andExpect(jsonPath("$.mainCamera").value("50 MP"))
+          .andExpect(jsonPath("$.batteryCapacity").value("4500 mAh"))
+          .andExpect(jsonPath("$.images").isArray())
+          .andExpect(jsonPath("$.images", hasSize(0)));
+    }
+
+    @Test
+    void whenProductDoesNotExist_thenReturn404() throws Exception {
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL + "/{id}", 999999L)
+                  .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void whenAuthenticatedUserHasNoAdminRole_thenStatus403() throws Exception {
+      Phone phone = phoneRepository.findAll().getFirst();
+
+      mockMvc
+          .perform(
+              get(ADMIN_PRODUCTS_URL + "/{id}", phone.getId())
+                  .header(HttpHeaders.AUTHORIZATION, auth(userToken)))
+          .andExpect(status().isForbidden());
     }
   }
 
@@ -155,7 +274,7 @@ class AdminControllerTest {
     return "Bearer " + token;
   }
 
-  private static PhoneCreateRequestDto buildPhoneCreateRequestDto() {
+  private static PhoneCreateRequestDto buildAdminTestPhoneCreateRequestDto() {
     return new PhoneCreateRequestDto(
         "Admin Test Phone",
         "Phone prepared for admin controller tests",
@@ -168,5 +287,35 @@ class AdminControllerTest {
         "12 MP",
         "50 MP",
         "4500 mAh");
+  }
+
+  private static PhoneCreateRequestDto buildOtherPhoneCreateRequestDto() {
+    return new PhoneCreateRequestDto(
+        "Other Device",
+        "Another phone for search and filter tests",
+        new BigDecimal("499.99"),
+        "OtherBrand",
+        2023,
+        "Other CPU",
+        6,
+        "6.1\"",
+        "10 MP",
+        "30 MP",
+        "4000 mAh");
+  }
+
+  private static PhoneCreateRequestDto buildMoreExpensivePhoneCreateRequestDto() {
+    return new PhoneCreateRequestDto(
+        "Premium Test Phone",
+        "More expensive phone for sorting tests",
+        new BigDecimal("1499.99"),
+        "PremiumBrand",
+        2025,
+        "Premium CPU",
+        10,
+        "6.8\"",
+        "16 MP",
+        "108 MP",
+        "5000 mAh");
   }
 }


### PR DESCRIPTION
## Summary

Implemented admin product catalog read endpoints under `/api/v1/admin/products/**`.

## Changes

- introduced dedicated admin product DTOs
- added admin query service and mapper
- added admin-specific filtering/search/sort support
- separated admin product contract from public phone/storefront contract
- added controller tests for list, details, search, filter, sort, and access control
