### PR TITLE
Feature/ntt 43/admin product read contract full

### DIFF
--- a/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductFilterDto.java
+++ b/src/main/java/com/challengeteam/shop/dto/admin/product/AdminProductFilterDto.java
@@ -1,5 +1,6 @@
 package com.challengeteam.shop.dto.admin.product;
 
+import com.challengeteam.shop.entity.phone.ProductStatus;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Pattern;
@@ -11,13 +12,14 @@ public record AdminProductFilterDto(
     @Size(max = 100, message = "Search length must be less than or equal to 100 characters")
         String search,
     String brand,
+    ProductStatus status,
     @DecimalMin(value = "0.0", message = "Minimum price cannot be negative") BigDecimal minPrice,
     @DecimalMin(value = "0.0", message = "Maximum price cannot be negative") BigDecimal maxPrice,
     @Pattern(
             regexp =
-                "name_asc|name_desc|price_asc|price_desc|releaseYear_asc|releaseYear_desc|brand_asc|brand_desc",
+                "name_asc|name_desc|price_asc|price_desc|releaseYear_asc|releaseYear_desc|brand_asc|brand_desc|sku_asc|sku_desc|stock_asc|stock_desc",
             message =
-                "Sort must be one of: name_asc, name_desc, price_asc, price_desc, releaseYear_asc, releaseYear_desc, brand_asc, brand_desc")
+                "Sort must be one of: name_asc, name_desc, price_asc, price_desc, releaseYear_asc, releaseYear_desc, brand_asc, brand_desc, sku_asc, sku_desc, stock_asc, stock_desc")
         String sort) {
   public AdminProductFilterDto {
     sort = (sort == null || sort.isBlank()) ? "name_asc" : sort;

--- a/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
+++ b/src/main/java/com/challengeteam/shop/persistence/specification/AdminProductSpecification.java
@@ -2,6 +2,7 @@ package com.challengeteam.shop.persistence.specification;
 
 import com.challengeteam.shop.dto.admin.product.AdminProductFilterDto;
 import com.challengeteam.shop.entity.phone.Phone;
+import com.challengeteam.shop.entity.phone.ProductStatus;
 import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -18,6 +19,7 @@ public final class AdminProductSpecification {
 
     spec = addIfHasText(spec, filterDto.search(), AdminProductSpecification::matchesSearch);
     spec = addIfHasText(spec, filterDto.brand(), AdminProductSpecification::hasBrand);
+    spec = addIfPresent(spec, filterDto.status(), AdminProductSpecification::hasStatus);
     spec =
         addIfPresent(
             spec, filterDto.minPrice(), AdminProductSpecification::priceGreaterThanOrEqual);
@@ -46,6 +48,7 @@ public final class AdminProductSpecification {
 
       return cb.or(
           cb.like(cb.lower(root.get("name")), pattern),
+          cb.like(cb.lower(root.get("sku")), pattern),
           cb.like(cb.lower(root.get("brand")), pattern),
           cb.like(cb.lower(root.get("description")), pattern));
     };
@@ -53,6 +56,10 @@ public final class AdminProductSpecification {
 
   private static Specification<Phone> hasBrand(String brand) {
     return (root, query, cb) -> cb.equal(cb.lower(root.get("brand")), brand.toLowerCase());
+  }
+
+  private static Specification<Phone> hasStatus(ProductStatus status) {
+    return (root, query, cb) -> cb.equal(root.get("status"), status);
   }
 
   private static Specification<Phone> priceGreaterThanOrEqual(BigDecimal minPrice) {

--- a/src/main/java/com/challengeteam/shop/service/admin/impl/AdminProductQueryServiceImpl.java
+++ b/src/main/java/com/challengeteam/shop/service/admin/impl/AdminProductQueryServiceImpl.java
@@ -54,6 +54,10 @@ public class AdminProductQueryServiceImpl implements AdminProductQueryService {
       case "releaseYear_desc" -> Sort.by("releaseYear").descending();
       case "brand_asc" -> Sort.by("brand").ascending();
       case "brand_desc" -> Sort.by("brand").descending();
+      case "sku_asc" -> Sort.by("sku").ascending();
+      case "sku_desc" -> Sort.by("sku").descending();
+      case "stock_asc" -> Sort.by("stock").ascending();
+      case "stock_desc" -> Sort.by("stock").descending();
       default -> Sort.by("name").ascending();
     };
   }

--- a/src/test/java/com/challengeteam/shop/web/controller/AdminControllerTest.java
+++ b/src/test/java/com/challengeteam/shop/web/controller/AdminControllerTest.java
@@ -333,4 +333,69 @@ class AdminControllerTest {
         "108 MP",
         "5000 mAh");
   }
+
+  @Test
+  void whenSearchMatchesSku_thenReturnFilteredList() throws Exception {
+    phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+    mockMvc
+        .perform(
+            get(ADMIN_PRODUCTS_URL)
+                .param("search", "ADMIN-TEST-001")
+                .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].sku").value("ADMIN-TEST-001"));
+  }
+
+  @Test
+  void whenStatusFilterMatchesProduct_thenReturnFilteredList() throws Exception {
+    phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+    mockMvc
+        .perform(
+            get(ADMIN_PRODUCTS_URL)
+                .param("status", "IN_STOCK")
+                .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].status").value("IN_STOCK"))
+        .andExpect(jsonPath("$.content[0].name").value("Admin Test Phone"));
+  }
+
+  @Test
+  void whenSortByStockDesc_thenReturnProductsInSortedOrder() throws Exception {
+    phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+    mockMvc
+        .perform(
+            get(ADMIN_PRODUCTS_URL)
+                .param("sort", "stock_desc")
+                .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content", hasSize(2)))
+        .andExpect(jsonPath("$.content[0].sku").value("ADMIN-TEST-001"))
+        .andExpect(jsonPath("$.content[0].stock").value(45))
+        .andExpect(jsonPath("$.content[1].sku").value("OTHER-DEVICE-001"))
+        .andExpect(jsonPath("$.content[1].stock").value(12));
+  }
+
+  @Test
+  void whenSortBySkuDesc_thenReturnProductsInSortedOrder() throws Exception {
+    phoneService.create(buildOtherPhoneCreateRequestDto(), new ArrayList<>());
+
+    mockMvc
+        .perform(
+            get(ADMIN_PRODUCTS_URL)
+                .param("sort", "sku_desc")
+                .header(HttpHeaders.AUTHORIZATION, auth(adminToken)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content", hasSize(2)))
+        .andExpect(jsonPath("$.content[0].sku").value("OTHER-DEVICE-001"))
+        .andExpect(jsonPath("$.content[1].sku").value("ADMIN-TEST-001"));
+  }
 }


### PR DESCRIPTION
- Product Management table can be rendered fully from backend data
- admin search works for both product name and sku
- admin filtering supports real UI fields already present in the domain
- admin sorting supports table columns used by the UI
- admin API remains stable and separated from public catalog contract